### PR TITLE
Missing template var is OK

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 # A list of CircleCI's Python versions is at https://circleci.com/docs/build-image-trusty/#python
 machine:
   post:
-    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.0
+    - pyenv global 2.7.12 3.4.4 3.5.3 3.6.2
 
 # If CircleCI sees a tox.ini file, it'll run tox, so nothing is needed here.

--- a/django_jsx/templatetags/jsx.py
+++ b/django_jsx/templatetags/jsx.py
@@ -1,6 +1,7 @@
 import re
 import json
 from hashlib import sha1
+import logging
 
 from django import template
 from django.template import TemplateSyntaxError
@@ -11,6 +12,7 @@ from django.template.base import TOKEN_VAR, TOKEN_BLOCK, Variable, VariableDoesN
 # and look like "ctx.foo.bar" or "ctx.3.xyz" etc.
 R_CTXEXPR = re.compile(r'\.*ctx\.([A-Za-z][\d\w\.]*)')
 
+logger = logging.getLogger(__name__)
 register = template.Library()
 
 
@@ -47,11 +49,18 @@ def serialize_opportunistically(context, expressions):
         try:
             value = Variable(expression).resolve(context)
         except VariableDoesNotExist:
-            raise VariableDoesNotExist(
-                "JSX block refers to ctx.%s, but there's no variable %s "
-                "in the Django template context." % (expression, expression))
-        else:
-            set_nested(ctx, expression, value)
+            logger.debug(
+                "JSX block refers to ctx.%s, but there's no variable by that name "
+                "in the Django template context.", expression)
+            if context.template:
+                string_if_invalid = context.template.engine.string_if_invalid
+            else:
+                string_if_invalid = ''
+            if '%s' in string_if_invalid:
+                value = string_if_invalid % expression
+            else:
+                value = string_if_invalid
+        set_nested(ctx, expression, value)
     ctx = json.dumps(ctx)
     return ctx
 

--- a/tests/test_jsx_tag.py
+++ b/tests/test_jsx_tag.py
@@ -104,6 +104,21 @@ class JsxTagTest(TestCase):
         expected_ctx = {'list': {'0': 1}}
         self.try_it(content, expected_ctx, context=context)
 
+    def test_missing_variables(self):
+        "If variable is missing, set it to empty string (by default)."
+        content = '''<Component prop2={ctx.does.not.exist}/>'''
+        context = {}
+        expected_ctx = {'does': {'not': {'exist': ''}}}
+        self.try_it(content, expected_ctx, context=context)
+
+    def test_missing_variables_with_string_if_invalid_set(self):
+        "If variable is missing, use Engine's string_if_invalid value."
+        ENGINE.string_if_invalid = 'hey, missing var -> %s'
+        content = '''<Component prop2={ctx.does.not.exist}/>'''
+        context = {}
+        expected_ctx = {'does': {'not': {'exist': 'hey, missing var -> does.not.exist'}}}
+        self.try_it(content, expected_ctx, context=context)
+
     # SHOULD NOT BE ALLOWED - compilejsx will reject
     # def test_two_identical_blocks_with_different_contexts(self):
     #     # If an identical block is repeated with different context values, we

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
-envlist = {py27,py34,py35}-{1.8}.X,{py27,py34,py35,py36}-{1.9}.X,{py27,py34,py35,py36}-{1.10}.X,flake8
-;,coverage
+envlist = {py27,py34,py35}-{1.8}.X
+          {py27,py34,py35,py36}-{1.9}.X
+          {py27,py34,py35,py36}-{1.10}.X
+          {py27,py34,py35,py36}-{1.11}.X
+          flake8
+          coverage
 
 [testenv]
 basepython =
@@ -12,19 +16,19 @@ deps =
     1.8.X: Django>=1.8,<1.9
     1.9.X: Django>=1.9,<1.10
     1.10.X: Django>=1.10,<1.11
+    1.11.X: Django>=1.11,<2.0
 commands = {envpython} runtests.py
 
 [testenv:flake8]
 basepython = python3.6
-deps = flake8
-       Django>=1.10,<1.11
+deps = flake8>=3.4
+       Django>=1.11,<2.0
 skip_install = true
 commands={envbindir}/flake8
 
 [testenv:coverage]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DISPLAY
-basepython = python3.5
+basepython = python3.6
 commands = coverage run runtests.py
-           coverage report -m --fail-under 80
+           coverage report -m --fail-under 90
 deps = coverage>=3.7.
-       Django<1.11
+       Django>=1.11,<2.0


### PR DESCRIPTION
This is another regression from 0.2.2 to 0.2.3.

If a variable is not defined in the context, django-jsx 0.2.2 does not complain but rather sets it to the empty string (like django templates normally work). Django-jsx 0.2.3, on the other hand, raises VariableDoesNotExist.

My guess is that this was an unintentional change, meant to improve the messaging, without actually causing an error. I thought that VariableDoesNotExist would be caught at a higher level inside Django and silenced, but that only occurs if you render the template through a certain code path (namely by rendering a FilterExpression). If you render a Variable, like we are doing, then nothing catches the VariableDoesNotExist, so I think we should catch it and handle it like [FilterExpression does](https://github.com/django/django/blob/master/django/template/base.py#L675-L686):
