### PR TITLE
Django 2.1 compatibility

### DIFF
--- a/django_jsx/templatetags/jsx.py
+++ b/django_jsx/templatetags/jsx.py
@@ -10,8 +10,8 @@ from django.template.base import Variable, VariableDoesNotExist
 
 if dj_version[:2] >= (2, 1):
     from django.template.base import TokenType
-    TOKEN_VAR = TokenType.VAR.value
-    TOKEN_BLOCK = TokenType.BLOCK.value
+    TOKEN_VAR = TokenType.VAR
+    TOKEN_BLOCK = TokenType.BLOCK
 else:
     from django.template.base import TOKEN_VAR, TOKEN_BLOCK
 

--- a/django_jsx/templatetags/jsx.py
+++ b/django_jsx/templatetags/jsx.py
@@ -3,10 +3,17 @@ import json
 from hashlib import sha1
 import logging
 
-from django import template
+from django import template, VERSION as dj_version
 from django.template import TemplateSyntaxError
 from django.utils.html import escape
-from django.template.base import TOKEN_VAR, TOKEN_BLOCK, Variable, VariableDoesNotExist
+from django.template.base import Variable, VariableDoesNotExist
+
+if dj_version[:2] >= (2, 1):
+    from django.template.base import TokenType
+    TOKEN_VAR = TokenType.VAR.value
+    TOKEN_BLOCK = TokenType.BLOCK.value
+else:
+    from django.template.base import TOKEN_VAR, TOKEN_BLOCK
 
 # Regex to find references to context that start with "ctx."
 # and look like "ctx.foo.bar" or "ctx.3.xyz" etc.

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = {py27,py34,py35}-{1.8}.X
           {py27,py34,py35,py36}-{1.9}.X
           {py27,py34,py35,py36}-{1.10}.X
           {py27,py34,py35,py36}-{1.11}.X
+          {py35,py36,py37}-{2.1}.X
           flake8
           coverage
 
@@ -12,11 +13,13 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     1.8.X: Django>=1.8,<1.9
     1.9.X: Django>=1.9,<1.10
     1.10.X: Django>=1.10,<1.11
     1.11.X: Django>=1.11,<2.0
+    2.1.X: Django>=2.1,<2.2
 commands = {envpython} runtests.py
 
 [testenv:flake8]


### PR DESCRIPTION
Django 2.1 moved django.template.base.TOKEN_* into [an Enum class](https://github.com/django/django/blob/stable/2.1.x/django/template/base.py#L100) called django.template.base.TokenType.  Import TOKEN_VAR and TOKEN_BLOCK from that class instead of the old location if Django has version >= 2.1.

This may not be the ideal solution, but it got me up and running again.  I won't be offended if you close this PR in favor of a better approach!

