### PR TITLE
Raise error if Django template syntax is used within a jsx block

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2017, Caktus Consulting Group, LLC
+Copyright (c) 2012-2019, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ the process.
   React component into each one using the template context from the script tag and the Javascript
   compiled from the original JSX.
 
+## Notes
+
+* `jsx` blocks cannot contain other `jsx` blocks, or other Django template features such as block
+  tags or context variables.
+
 ## License
 
 django-jsx is released under the BSD License. See the

--- a/django_jsx/templatetags/jsx.py
+++ b/django_jsx/templatetags/jsx.py
@@ -8,12 +8,11 @@ from django.template import TemplateSyntaxError
 from django.utils.html import escape
 from django.template.base import Variable, VariableDoesNotExist
 
-if dj_version[:2] >= (2, 1):
+if dj_version[:2] >= (2, 1):  # pragma: nocover
     from django.template.base import TokenType
-    TOKEN_VAR = TokenType.VAR
-    TOKEN_BLOCK = TokenType.BLOCK
+    TOKEN_TEXT = TokenType.TEXT
 else:
-    from django.template.base import TOKEN_VAR, TOKEN_BLOCK
+    from django.template.base import TOKEN_TEXT
 
 # Regex to find references to context that start with "ctx."
 # and look like "ctx.foo.bar" or "ctx.3.xyz" etc.
@@ -118,20 +117,10 @@ def jsx(parser, token):
         if token.contents == 'endjsx':
             break
 
-        if token.contents == 'jsx':
-            raise TemplateSyntaxError("jsx blocks cannot be nested in a template")
-
-        if token.token_type == TOKEN_VAR:
-            text.append('{{')
-        elif token.token_type == TOKEN_BLOCK:
-            text.append('{%')
+        if token.token_type != TOKEN_TEXT:
+            raise TemplateSyntaxError("jsx blocks cannot contain Django Template syntax.")
 
         text.append(token.contents)
-
-        if token.token_type == TOKEN_VAR:
-            text.append('}}')
-        elif token.token_type == TOKEN_BLOCK:
-            text.append('%}')
 
     return JsxNode(''.join(text))
 

--- a/tests/test_jsx_tag.py
+++ b/tests/test_jsx_tag.py
@@ -175,16 +175,26 @@ class JsxTagTest(TestCase):
             .replace('SHA1', sha1))
         self.assertEqual(expected_output, unescape(result))
 
-    def test_nested_blocks(self):
-        # Nested JSX blocks are not allowed
+    def test_django_var(self):
+        # Django variables are not allowed
         test_content = '''
         {% load jsx %}
         {% jsx %}
-            <Component1>
-                {% jsx %}<Component2/>{% endjsx %}
-            </Component1>
+          {{ my_var }}
         {% endjsx %}'''
         with self.assertRaises(TemplateSyntaxError) as raise_context:
             self.try_it(test_content, None, raw=True,)
-            exc = raise_context.exc
-            self.assertIn('jsx blocks cannot be nested in a template', str(exc))
+        exc = raise_context.exception
+        self.assertIn('jsx blocks cannot contain Django Template syntax', str(exc))
+
+    def test_django_block(self):
+        # Django blocks are not allowed
+        test_content = '''
+        {% load jsx %}
+        {% jsx %}
+          {% if is_true %}{% endif %}
+        {% endjsx %}'''
+        with self.assertRaises(TemplateSyntaxError) as raise_context:
+            self.try_it(test_content, None, raw=True,)
+        exc = raise_context.exception
+        self.assertIn('jsx blocks cannot contain Django Template syntax', str(exc))


### PR DESCRIPTION
Closes #8 